### PR TITLE
chore: support Node.js 24 in engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "pfx"
   ],
   "engines": {
-    "node": ">=18 <=22 || ^16"
+    "node": ">=18 || ^16"
   },
   "browserslist": [
     "defaults",


### PR DESCRIPTION
Closes #40

## Summary
- Removes the upper bound (`<=22`) from the `engines.node` constraint so the package installs cleanly on Node 24 (and any future even-LTS) without an `Unsupported engine` warning from npm/pnpm.
- New constraint: `>=18 || ^16` (preserves existing Node 16 support).

## Why
Installing `@nodecfdi/credentials@3.2.0` on Node 24 currently emits:
```
WARN  Unsupported engine: wanted: {"node":">=18 <=22 || ^16"} (current: {"node":"v24.15.0"})
```
The runtime code itself works fine on Node 24 — only the metadata blocks it.

## Verification (Node 24.15.0)
- `pnpm install` — resolves cleanly
- `pnpm typecheck` — passes
- `pnpm test:run` — 114/114 tests pass across 15 files